### PR TITLE
Fix Play upload path for downloaded release bundle.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           serviceAccountJson: service_account.json
           packageName: com.doubleangels.redact
-          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          releaseFiles: app-release.aab
           tracks: production
           whatsNewDirectory: whatsnew
 


### PR DESCRIPTION
The publish job downloads the signed AAB to the workspace root, so upload-google-play must reference app-release.aab, not the Gradle output path.